### PR TITLE
各旅程を日付でグループ分けして表示 / 各viewにsectionタグの追加

### DIFF
--- a/app/Http/Controllers/Dashboard/TripController.php
+++ b/app/Http/Controllers/Dashboard/TripController.php
@@ -60,7 +60,13 @@ class TripController extends Controller
             $query->orderBy('date_and_time', 'asc');
         }])->findOrFail($trip_id);
 
-        return view('dashboard.trips.show', compact('trip'));
+        $groupedItineraries = $trip->itineraries
+            ->sortBy('date_and_time')
+            ->groupBy(function ($itinerary) {
+                return \Carbon\Carbon::parse($itinerary->date_and_time)->format('Y-m-d');
+            });
+            
+        return view('dashboard.trips.show', compact('trip', 'groupedItineraries'));
     }
 
 

--- a/app/Http/Controllers/Dashboard/TripController.php
+++ b/app/Http/Controllers/Dashboard/TripController.php
@@ -56,9 +56,7 @@ class TripController extends Controller
      */
     public function show($trip_id)
     {
-        $trip = Trip::with(['itineraries' => function ($query) {
-            $query->orderBy('date_and_time', 'asc');
-        }])->findOrFail($trip_id);
+        $trip = Trip::findOrFail($trip_id);
 
         $groupedItineraries = $trip->itineraries
             ->sortBy('date_and_time')
@@ -75,13 +73,7 @@ class TripController extends Controller
      */
     public function edit(string $trip_id)
     {
-        $trip = Trip::where('id', $trip_id)
-            ->select('id', 'start_date', 'end_date', 'title', 'destination')
-            ->first();
-
-        if (!$trip) {
-            return redirect()->route('dashboard.trips.index')->with('error', '旅のしおりが見つかりませんでした。');
-        }
+        $trip = Trip::findOrFail($trip_id);
 
         return view('dashboard.trips.edit', compact('trip'));
     }
@@ -91,13 +83,7 @@ class TripController extends Controller
      */
     public function update(TripRequest $request, string $trip_id)
     {
-        $trip = Trip::where('id', $trip_id)
-            ->select('id', 'start_date', 'end_date', 'title', 'destination')
-            ->first();
-
-        if (!$trip) {
-            return redirect()->route('dashboard.trips.index')->with('error', '旅のしおりが見つかりませんでした。');
-        }
+        $trip = Trip::findOrFail($trip_id);
 
         $trip->start_date = $request->start_date;
         $trip->end_date = $request->end_date;
@@ -113,12 +99,7 @@ class TripController extends Controller
      */
     public function destroy(string $trip_id)
     {
-        $trip = Trip::find($trip_id);
-
-        if (!$trip) {
-            return redirect()->route('dashboard.trips.index')->with('error', '旅のしおりが見つかりませんでした。');
-        }
-
+        $trip = Trip::findOrFail($trip_id);
         $trip->delete();
 
         return to_route('dashboard.trips.index');

--- a/resources/views/dashboard/itineraries/show.blade.php
+++ b/resources/views/dashboard/itineraries/show.blade.php
@@ -8,14 +8,15 @@
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
             <section>
+                <h2 class="text-2xl font-bold mb-4 mt-6">📅 {{ \Carbon\Carbon::parse($itinerary->date_and_time )->format('Y年m月d日') }}</h2>
                 <div class="relative flex flex-col mb-8 p-6 border rounded-lg border-gray-300 bg-gray-50">
                     <h3 class="mb-2 text-xl font-bold">🗺 {{ $itinerary->title }}</h3>
-                    <p class="mb-3">⌚️ {{ $itinerary->date_and_time }}</p>
+                    <p class="mb-3">⌚️ {{ \Carbon\Carbon::parse($itinerary->date_and_time)->format('H:i') }}</p>
                     <p class="mt-2">{{ $itinerary->content }}</p>
                     @if ($itinerary->hide_content)
-                    <button class="mt-4 hover:underline text-gray-500">
+                    <p class="text-center mt-4 text-gray-500">
                         🔽 補足情報を表示 🔽
-                    </button>
+                    </p>
                     <div class="mt-4 p-4">
                         {{ $itinerary->hide_content }}
                     </div>

--- a/resources/views/dashboard/memos/create.blade.php
+++ b/resources/views/dashboard/memos/create.blade.php
@@ -7,11 +7,13 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <x-form.form-container method="POST" action="{{ route('dashboard.trips.memos.store', ['trip_id' => $trip_id]) }}"
-                title="メモの登録" buttonTitle="新規登録する" backRoute="{{ route('dashboard.trips.memos.index', ['trip_id' => $trip_id]) }}">
-                <x-form.input name="title">メモのタイトル</x-form.input>
-                <x-form.textarea name="content">メモする内容</x-form.textarea>
-            </x-form.form-container>
+            <section>
+                <x-form.form-container method="POST" action="{{ route('dashboard.trips.memos.store', ['trip_id' => $trip_id]) }}"
+                    title="メモの登録" buttonTitle="新規登録する" backRoute="{{ route('dashboard.trips.memos.index', ['trip_id' => $trip_id]) }}">
+                    <x-form.input name="title">メモのタイトル</x-form.input>
+                    <x-form.textarea name="content">メモする内容</x-form.textarea>
+                </x-form.form-container>
+            </section>
         </div>
     </div>
 

--- a/resources/views/dashboard/memos/edit.blade.php
+++ b/resources/views/dashboard/memos/edit.blade.php
@@ -7,14 +7,16 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <x-form.form-container method="POST" action="{{ route('dashboard.trips.memos.update', ['trip_id' => $memo->trip_id, 'memo_id' =>$memo->id]) }}"
-                title="メモの編集" buttonTitle="編集する" backRoute="{{ route('dashboard.trips.memos.show', ['trip_id' => $memo->trip_id, 'memo_id' =>$memo->id]) }}">
-                @method('PUT')
-                <x-form.input name="title" value="{{ $memo->title }}">メモタイトル</x-form.input>
-                <x-form.textarea name="content" value="{{ $memo->content }}">メモの内容</x-form.textarea>
-            </x-form.form-container>
-            <x-ui.delete-modal title="{{ $memo->title }}" buttonTitle="削除する"
-                action="{{ route('dashboard.trips.memos.destroy', ['trip_id' => $memo->trip_id, 'memo_id' => $memo->id]) }}" />
+            <section>
+                <x-form.form-container method="POST" action="{{ route('dashboard.trips.memos.update', ['trip_id' => $memo->trip_id, 'memo_id' =>$memo->id]) }}"
+                    title="メモの編集" buttonTitle="編集する" backRoute="{{ route('dashboard.trips.memos.show', ['trip_id' => $memo->trip_id, 'memo_id' =>$memo->id]) }}">
+                    @method('PUT')
+                    <x-form.input name="title" value="{{ $memo->title }}">メモタイトル</x-form.input>
+                    <x-form.textarea name="content" value="{{ $memo->content }}">メモの内容</x-form.textarea>
+                </x-form.form-container>
+                <x-ui.delete-modal title="{{ $memo->title }}" buttonTitle="削除する"
+                    action="{{ route('dashboard.trips.memos.destroy', ['trip_id' => $memo->trip_id, 'memo_id' => $memo->id]) }}" />
+            </section>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/dashboard/memos/index.blade.php
+++ b/resources/views/dashboard/memos/index.blade.php
@@ -7,27 +7,29 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
-                @foreach ($memos as $memo)
-                <div class="relative p-6 border rounded-lg shadow-lg hover:shadow-2xl transition-shadow border-gray-300 bg-gray-50">
-                    <h3 class="pb-1 mt-2 mb-4 text-xl text-center font-bold border-b border-dashed border-gray-700">{{ $memo->title }}</h3>
-                    <p>{{ $memo->content }}</p>
-                    <x-ui.button-link
-                        route="{{ route('dashboard.trips.memos.show', ['trip_id' => $memo->trip_id, 'memo_id' => $memo->id]) }}"
-                        size="mini" color="gray"
-                        class="absolute top-0 right-0 rounded">
-                        📝詳細
-                    </x-ui.button-link>
+            <section>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+                    @foreach ($memos as $memo)
+                    <div class="relative p-6 border rounded-lg shadow-lg hover:shadow-2xl transition-shadow border-gray-300 bg-gray-50">
+                        <h3 class="pb-1 mt-2 mb-4 text-xl text-center font-bold border-b border-dashed border-gray-700">{{ $memo->title }}</h3>
+                        <p>{{ $memo->content }}</p>
+                        <x-ui.button-link
+                            route="{{ route('dashboard.trips.memos.show', ['trip_id' => $memo->trip_id, 'memo_id' => $memo->id]) }}"
+                            size="mini" color="gray"
+                            class="absolute top-0 right-0 rounded">
+                            📝詳細
+                        </x-ui.button-link>
+                    </div>
+                    @endforeach
+                    <a href="{{ route('dashboard.trips.memos.create', ['trip_id' => $trip->id] ) }}" class="flex items-center justify-center min-h-[130px] p-6 rounded-lg shadow-md hover:shadow-lg border border-blue-300 bg-white hover:bg-blue-200 transition cursor-pointer">
+                        ➕
+                    </a>
                 </div>
-                @endforeach
-                <a href="{{ route('dashboard.trips.memos.create', ['trip_id' => $trip->id] ) }}" class="flex items-center justify-center min-h-[130px] p-6 rounded-lg shadow-md hover:shadow-lg border border-blue-300 bg-white hover:bg-blue-200 transition cursor-pointer">
-                    ➕
-                </a>
-            </div>
-            <div class="my-8">
-                {{ $memos->links() }}
-            </div>
-            <x-ui.button-link route="{{ route('dashboard.trips.show', ['trip_id' => $trip->id]) }}" size="normal" color="green" class="block mx-auto w-[180px] rounded">旅程へ</x-ui.button-link>
+                <div class="my-8">
+                    {{ $memos->links() }}
+                </div>
+                <x-ui.button-link route="{{ route('dashboard.trips.show', ['trip_id' => $trip->id]) }}" size="normal" color="green" class="block mx-auto w-[180px] rounded">旅程へ</x-ui.button-link>
+            </section>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/dashboard/memos/show.blade.php
+++ b/resources/views/dashboard/memos/show.blade.php
@@ -7,16 +7,18 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <div class="w-full max-w-[600px] mx-auto mb-8 p-6 border rounded-lg shadow-lg hover:shadow-2xl transition-shadow border-gray-300 bg-gray-50">
-                <h3 class="pb-1 mt-2 mb-4 text-xl text-center font-bold border-b border-dashed border-gray-700">{{ $memo->title }}</h3>
-                <p>{{ $memo->content }}</p>
-            </div>
-            <x-ui.button-link route="{{ route('dashboard.trips.memos.edit', ['trip_id' => $memo->trip_id, 'memo_id' => $memo->id]) }}" size="normal" color="blue" class="block w-[180px] mx-auto rounded">
-                編集する
-            </x-ui.button-link>
-            <x-ui.button-link route="{{ route('dashboard.trips.memos.index', ['trip_id' => $memo->trip_id]) }}" size="normal" color="gray" class="block w-[180px] mx-auto rounded">
-                メモの一覧
-            </x-ui.button-link>
+            <section>
+                <div class="w-full max-w-[600px] mx-auto mb-8 p-6 border rounded-lg shadow-lg hover:shadow-2xl transition-shadow border-gray-300 bg-gray-50">
+                    <h3 class="pb-1 mt-2 mb-4 text-xl text-center font-bold border-b border-dashed border-gray-700">{{ $memo->title }}</h3>
+                    <p>{{ $memo->content }}</p>
+                </div>
+                <x-ui.button-link route="{{ route('dashboard.trips.memos.edit', ['trip_id' => $memo->trip_id, 'memo_id' => $memo->id]) }}" size="normal" color="blue" class="block w-[180px] mx-auto rounded">
+                    編集する
+                </x-ui.button-link>
+                <x-ui.button-link route="{{ route('dashboard.trips.memos.index', ['trip_id' => $memo->trip_id]) }}" size="normal" color="gray" class="block w-[180px] mx-auto rounded">
+                    メモの一覧
+                </x-ui.button-link>
+            </section>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/dashboard/trips/create.blade.php
+++ b/resources/views/dashboard/trips/create.blade.php
@@ -7,19 +7,21 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <x-form.form-container method="POST" action="{{ route('dashboard.trips.store') }}" title="旅のしおりの登録" buttonTitle="新規登録する" backRoute="{{ route('dashboard.trips.index') }}">
-                @csrf
-                <div class="flex justify-center">
-                    <div class="flex flex-col mr-8">
-                        <x-form.input name="start_date" type="date">出発日</x-form.input>
+            <section>
+                <x-form.form-container method="POST" action="{{ route('dashboard.trips.store') }}"
+                    title="旅のしおりの登録" buttonTitle="新規登録する" backRoute="{{ route('dashboard.trips.index') }}">
+                    <div class="flex justify-center">
+                        <div class="flex flex-col mr-8">
+                            <x-form.input name="start_date" type="date">出発日</x-form.input>
+                        </div>
+                        <div class="flex flex-col">
+                            <x-form.input name="end_date" type="date">帰宅日</x-form.input>
+                        </div>
                     </div>
-                    <div class="flex flex-col">
-                        <x-form.input name="end_date" type="date">帰宅日</x-form.input>
-                    </div>
-                </div>
-                <x-form.input name="title">旅のしおりのタイトル</x-form.input>
-                <x-form.input name="destination">旅行先</x-form.input>
-            </x-form.form-container>
+                    <x-form.input name="title">旅のしおりのタイトル</x-form.input>
+                    <x-form.input name="destination">旅行先</x-form.input>
+                </x-form.form-container>
+            </section>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/dashboard/trips/edit.blade.php
+++ b/resources/views/dashboard/trips/edit.blade.php
@@ -7,22 +7,24 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <x-form.form-container method="POST" action="{{ route('dashboard.trips.update', [$trip->id]) }}"
-                title="旅のしおりの編集" buttonTitle="編集する" backRoute="{{ route('dashboard.trips.show', ['trip_id' => $trip->id]) }}">
-                @method('PUT')
-                <div class="flex justify-center">
-                    <div class="flex flex-col mr-8">
-                        <x-form.input name="start_date" type="date" value="{{ $trip->start_date }}">出発日</x-form.input>
+            <section>
+                <x-form.form-container method="POST" action="{{ route('dashboard.trips.update', [$trip->id]) }}"
+                    title="旅のしおりの編集" buttonTitle="編集する" backRoute="{{ route('dashboard.trips.show', ['trip_id' => $trip->id]) }}">
+                    @method('PUT')
+                    <div class="flex justify-center">
+                        <div class="flex flex-col mr-8">
+                            <x-form.input name="start_date" type="date" value="{{ $trip->start_date }}">出発日</x-form.input>
+                        </div>
+                        <div class="flex flex-col">
+                            <x-form.input name="end_date" type="date" value="{{ $trip->end_date }}">帰宅日</x-form.input>
+                        </div>
                     </div>
-                    <div class="flex flex-col">
-                        <x-form.input name="end_date" type="date" value="{{ $trip->end_date }}">帰宅日</x-form.input>
-                    </div>
-                </div>
-                <x-form.input name="title" value="{{ $trip->title }}">旅のしおりのタイトル</x-form.input>
-                <x-form.input name="destination" value="{{ $trip->destination }}">旅行先</x-form.input>
-            </x-form.form-container>
-            <x-ui.delete-modal title="{{ $trip->title }}" buttonTitle="削除する"
-                action="{{ route('dashboard.trips.destroy', [ 'trip_id' => $trip->id ]) }}" />
+                    <x-form.input name="title" value="{{ $trip->title }}">旅のしおりのタイトル</x-form.input>
+                    <x-form.input name="destination" value="{{ $trip->destination }}">旅行先</x-form.input>
+                </x-form.form-container>
+                <x-ui.delete-modal title="{{ $trip->title }}" buttonTitle="削除する"
+                    action="{{ route('dashboard.trips.destroy', [ 'trip_id' => $trip->id ]) }}" />
+            </section>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/dashboard/trips/index.blade.php
+++ b/resources/views/dashboard/trips/index.blade.php
@@ -7,25 +7,27 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto p-6 bg-white shadow-sm">
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 text-gray-900">
-                @foreach ($trips as $trip)
-                <div class="p-6 rounded-lg shadow-md hover:shadow-lg border border-gray-300 bg-white">
-                    <div class="flex">
-                        <span class="mr-1 text-xl">🗺</span>
-                        <h3 class="text-xl font-semibold">{{ $trip->title }}</h3>
+            <section>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 text-gray-900">
+                    @foreach ($trips as $trip)
+                    <div class="p-6 rounded-lg shadow-md hover:shadow-lg border border-gray-300 bg-white">
+                        <div class="flex">
+                            <span class="mr-1 text-xl">🗺</span>
+                            <h3 class="text-xl font-semibold">{{ $trip->title }}</h3>
+                        </div>
+                        <p class="py-2">{{ $trip->destination }}</p>
+                        <div class="pt-2 pb-4">
+                            <p>✈️ {{ $trip->start_date }}</p>
+                            <p>🏠 {{ $trip->end_date }}</p>
+                        </div>
+                        <a href="{{ route('dashboard.trips.show', ['trip_id' => $trip->id]) }}" class="font-medium text-sky-500 hover:text-sky-600 transition">詳細を見る →</a>
                     </div>
-                    <p class="py-2">{{ $trip->destination }}</p>
-                    <div class="pt-2 pb-4">
-                        <p>✈️ {{ $trip->start_date }}</p>
-                        <p>🏠 {{ $trip->end_date }}</p>
-                    </div>
-                    <a href="{{ route('dashboard.trips.show', ['trip_id' => $trip->id]) }}" class="font-medium text-sky-500 hover:text-sky-600 transition">詳細を見る →</a>
+                    @endforeach
+                    <a href="{{ route('dashboard.trips.create') }}" class="flex items-center justify-center min-h-[210px] p-6 rounded-lg shadow-md hover:shadow-lg border border-blue-300 bg-white hover:bg-blue-200 transition cursor-pointer ">
+                        ➕
+                    </a>
                 </div>
-                @endforeach
-                <a href="{{ route('dashboard.trips.create') }}" class="flex items-center justify-center min-h-[210px] p-6 rounded-lg shadow-md hover:shadow-lg border border-blue-300 bg-white hover:bg-blue-200 transition cursor-pointer ">
-                    ➕
-                </a>
-            </div>
+            </section>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/dashboard/trips/show.blade.php
+++ b/resources/views/dashboard/trips/show.blade.php
@@ -7,16 +7,17 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-
             <!-- 旅程の一覧表示のセクション -->
             <section>
-                @foreach ($trip->itineraries as $itinerary)
+                @foreach ($groupedItineraries as $date  => $items)
+                <h2 class="text-2xl font-bold mb-4 mt-6">📅 {{ \Carbon\Carbon::parse($date )->format('Y年m月d日') }}</h2>
+                @foreach ($items as $itinerary)
                 <div class="relative flex flex-col mb-8 p-6 border rounded-lg border-gray-300 bg-gray-50">
                     <h3 class="mb-2 text-xl font-bold">🗺 {{ $itinerary->title }}</h3>
-                    <p class="mb-3">⌚️ {{ $itinerary->date_and_time }}</p>
+                    <p class="mb-3">⌚️ {{ \Carbon\Carbon::parse($itinerary->date_and_time)->format('H:i') }}</p>
                     <p class="mt-2">{{ $itinerary->content }}</p>
                     @if ($itinerary->hide_content)
-                    <button onclick="toggleContent('{{ $itinerary->id }}')"  class="mt-4 hover:underline text-gray-500">
+                    <button onclick="toggleContent('{{ $itinerary->id }}')" class="mt-4 hover:underline text-gray-500">
                         🔽 補足情報を表示 🔽
                     </button>
                     <div id="{{ $itinerary->id }}" class="hidden mt-4 p-4">
@@ -31,6 +32,8 @@
                     </x-ui.button-link>
                 </div>
                 @endforeach
+                @endforeach
+
                 <a href="{{ route('dashboard.trips.itineraries.create', ['trip_id' => $trip->id] ) }}" class="flex items-center justify-center min-h-[150px] mb-8 p-6 rounded-lg border border-blue-300 bg-white hover:bg-blue-200 transition cursor-pointer">
                     ➕
                 </a>

--- a/resources/views/dashboard/trips/show.blade.php
+++ b/resources/views/dashboard/trips/show.blade.php
@@ -7,9 +7,9 @@
 
     <div class="py-12">
         <div class="max-w-7xl w-full mx-auto p-6 bg-white shadow-sm">
-            <!-- 旅程の一覧表示のセクション -->
+            <!-- 旅程の一覧表示 -->
             <section>
-                @foreach ($groupedItineraries as $date  => $items)
+                @foreach ($groupedItineraries as $date => $items)
                 <h2 class="text-2xl font-bold mb-4 mt-6">📅 {{ \Carbon\Carbon::parse($date )->format('Y年m月d日') }}</h2>
                 @foreach ($items as $itinerary)
                 <div class="relative flex flex-col mb-8 p-6 border rounded-lg border-gray-300 bg-gray-50">
@@ -40,7 +40,7 @@
                 <x-ui.button-link route="{{ route('dashboard.trips.memos.index', ['trip_id' => $trip->id]) }}" size="normal" color="green" class="block mx-auto w-[180px] rounded">メモの一覧へ</x-ui.button-link>
             </section>
 
-            <!-- 旅のしおりの詳細セクション -->
+            <!-- 旅のしおりの詳細 -->
             <section>
                 <div class="relative w-full max-w-[450px] mx-auto p-4 my-16 border border-dashed rounded border-gray-800 ">
                     <p>タイトル：{{ $trip->title }}</p>
@@ -56,7 +56,6 @@
                 </div>
                 <x-ui.button-link route="{{ route('dashboard.trips.index') }}" size="normal" color="gray" class="block mx-auto w-[180px] rounded">旅のしおりの一覧</x-ui.button-link>
             </section>
-
         </div>
     </div>
 </x-app-layout>


### PR DESCRIPTION
## 各旅程を日付でグループ分けして表示
- tripのshowのcontrollerでitineraryを日付でグループ分け
- tripのshowのviewで旅程を日付別に表示に変更
- itineraryのshowのviewで日付や時間の表示方法を変更

旅程表の表示方法を変更。
旅程を各日付でグループ分けして表示に変更。
それに伴い、各旅程が日付と時間の表示をしていたのを時間のみの表示に変更をしている。

## 各viewにsectionタグの追加
- tripsの各種viewにsectionタグの追加
- memoの各種viewにsectionタグの追加