### PR TITLE
フッターメニューの作成（スマホ風デザイン）

### DIFF
--- a/resources/views/components/ui/footer-menu.blade.php
+++ b/resources/views/components/ui/footer-menu.blade.php
@@ -1,5 +1,6 @@
 @php
-    $tripId = request()->route('trip_id');
+$tripId = request()->route('trip_id');
+$currentRoute = Route::currentRouteName();
 @endphp
 
 @if($tripId)
@@ -11,6 +12,15 @@
             class="text-gray-700 hover:bg-gray-200">旅程表</a>
         <a href="{{ route('dashboard.trips.memos.index', ['trip_id' =>$tripId ]) }}"
             class="text-gray-700 hover:bg-gray-200">メモ一覧</a>
+
+        <!-- ➕ボタンのルート切り替え -->
+        @if ($currentRoute === 'dashboard.trips.show' || $currentRoute === 'dashboard.trips.itineraries.create')
+        <a href="{{ route('dashboard.trips.itineraries.create', ['trip_id' => $tripId]) }}"
+            class="text-gray-700 hover:bg-gray-200">➕</a>
+        @elseif ($currentRoute === 'dashboard.trips.memos.index' || $currentRoute === 'dashboard.trips.memos.create')
+        <a href="{{ route('dashboard.trips.memos.create', ['trip_id' => $tripId]) }}"
+            class="text-gray-700 hover:bg-gray-200">➕</a>
+        @endif
     </div>
 </div>
 @endif

--- a/resources/views/components/ui/footer-menu.blade.php
+++ b/resources/views/components/ui/footer-menu.blade.php
@@ -4,23 +4,46 @@ $currentRoute = Route::currentRouteName();
 @endphp
 
 @if($tripId)
-<div class="footer-menu fixed bottom-0 w-full bg-white  border-gray-400 border-t">
-    <div class="flex justify-around py-2">
-        <a href="{{ route('dashboard.trips.index') }}"
-            class="text-gray-700 hover:bg-gray-200">旅のしおり</a>
-        <a href="{{ route('dashboard.trips.show', ['trip_id' =>$tripId ]) }}"
-            class="text-gray-700 hover:bg-gray-200">旅程表</a>
-        <a href="{{ route('dashboard.trips.memos.index', ['trip_id' =>$tripId ]) }}"
-            class="text-gray-700 hover:bg-gray-200">メモ一覧</a>
+<nav class="fixed w-full bottom-0 border-t border-gray-300 bg-white z-50">
+    <ul class="flex justify-around items-center text-center h-[64px]">
+        <li class="w-full hover:bg-sky-200 transition-all duration-200">
+            <a href="{{ route('dashboard.trips.index') }}"
+                class="flex flex-col justify-center items-center w-full h-full py-1">
+                <span>🗺</span>
+                <span class="mt-1 text-sm">旅のしおり</span>
+            </a>
+        </li>
+        <li class="w-full hover:bg-sky-200 transition-all duration-200">
+            <a href="{{ route('dashboard.trips.show', ['trip_id' => $tripId]) }}"
+                class="flex flex-col justify-center items-center w-full h-full py-1">
+                <span>📅</span>
+                <span class="mt-1 text-sm">旅程表</span>
+            </a>
+        </li>
+        <li class="w-full hover:bg-sky-200 transition-all duration-200">
+            <a href="{{ route('dashboard.trips.memos.index', ['trip_id' => $tripId]) }}"
+                class="flex flex-col justify-center items-center w-full h-full py-1">
+                <span>📝</span>
+                <span class="mt-1 text-sm">メモ一覧</span>
+            </a>
+        </li>
 
-        <!-- ➕ボタンのルート切り替え -->
-        @if ($currentRoute === 'dashboard.trips.show' || $currentRoute === 'dashboard.trips.itineraries.create')
-        <a href="{{ route('dashboard.trips.itineraries.create', ['trip_id' => $tripId]) }}"
-            class="text-gray-700 hover:bg-gray-200">➕</a>
-        @elseif ($currentRoute === 'dashboard.trips.memos.index' || $currentRoute === 'dashboard.trips.memos.create')
-        <a href="{{ route('dashboard.trips.memos.create', ['trip_id' => $tripId]) }}"
-            class="text-gray-700 hover:bg-gray-200">➕</a>
-        @endif
-    </div>
-</div>
+        <!-- ➕ボタンはルート切り替え -->
+        <li class="w-full hover:bg-sky-200 transition-all duration-200">
+            @if ($currentRoute === 'dashboard.trips.show' || $currentRoute === 'dashboard.trips.itineraries.create')
+            <a href="{{ route('dashboard.trips.itineraries.create', ['trip_id' => $tripId]) }}"
+                class="flex flex-col justify-center items-center w-full h-full py-1">
+                <span>➕</span>
+                <span class="mt-1 text-sm">新規作成</span>
+            </a>
+            @elseif ($currentRoute === 'dashboard.trips.memos.index' || $currentRoute === 'dashboard.trips.memos.create')
+            <a href="{{ route('dashboard.trips.memos.create', ['trip_id' => $tripId]) }}"
+                class="flex flex-col justify-center items-center w-full h-full py-1">
+                <span>➕</span>
+                <span class="mt-1 text-sm">新規作成</span>
+            </a>
+            @endif
+        </li>
+    </ul>
+</ｎ>
 @endif

--- a/resources/views/components/ui/footer-menu.blade.php
+++ b/resources/views/components/ui/footer-menu.blade.php
@@ -1,0 +1,16 @@
+@php
+    $tripId = request()->route('trip_id');
+@endphp
+
+@if($tripId)
+<div class="footer-menu fixed bottom-0 w-full bg-white  border-gray-400 border-t">
+    <div class="flex justify-around py-2">
+        <a href="{{ route('dashboard.trips.index') }}"
+            class="text-gray-700 hover:bg-gray-200">旅のしおり</a>
+        <a href="{{ route('dashboard.trips.show', ['trip_id' =>$tripId ]) }}"
+            class="text-gray-700 hover:bg-gray-200">旅程表</a>
+        <a href="{{ route('dashboard.trips.memos.index', ['trip_id' =>$tripId ]) }}"
+            class="text-gray-700 hover:bg-gray-200">メモ一覧</a>
+    </div>
+</div>
+@endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -31,6 +31,7 @@
             <main>
                 {{ $slot }}
             </main>
+            <x-ui.footer-menu />
         </div>
     </body>
 </html>


### PR DESCRIPTION
## フッターメニューの作成
- 旅のしおりのページのみに表示予定のfooterコンポーネントの作成
- footerMenuに各ルートによって変更するcreateページへのリンクを追加
- footerNenuのデザインをスマホ風のデザインに変更

下部に固定のフッターメニューの作成。
旅程が増えると新規作成ページへのリンクにスクロールする手間があった。
固定表示にすることですぐに旅程を追加したい時にフォームが表示できるようになった。
また、同様に旅程表とメモの切り替えがすぐに行えるようになった。




